### PR TITLE
Error handling: Don't overwrite downloaded files on error

### DIFF
--- a/.github/workflows/tles.yml
+++ b/.github/workflows/tles.yml
@@ -18,18 +18,18 @@ jobs:
         
       - name: Run a multi-line script
         run: |
-          curl -L -o last-30-days.txt           "https://celestrak.org/NORAD/elements/gp.php?GROUP=last-30-days&FORMAT=tle"
-          curl -L -o space-stations.txt         "https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=tle"
-          curl -L -o 100-brightest.txt          "https://celestrak.org/NORAD/elements/gp.php?GROUP=visual&FORMAT=tle"
-          curl -L -o active.txt                 "https://celestrak.org/NORAD/elements/gp.php?GROUP=active&FORMAT=tle"
-          curl -L -o analyst.txt                "https://celestrak.org/NORAD/elements/gp.php?GROUP=analyst&FORMAT=tle"
-          curl -L -o last-30-days-omm-kvn.txt   "https://celestrak.org/NORAD/elements/gp.php?GROUP=last-30-days&FORMAT=kvn"
-          curl -L -o space-stations-omm-kvn.txt "https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=kvn"
-          curl -L -o 100-brightest-omm-kvn.txt  "https://celestrak.org/NORAD/elements/gp.php?GROUP=visual&FORMAT=kvn"
-          curl -L -o active-omm-kvn.txt         "https://celestrak.org/NORAD/elements/gp.php?GROUP=active&FORMAT=kvn"
-          curl -L -o analyst-omm-kvn.txt        "https://celestrak.org/NORAD/elements/gp.php?GROUP=analyst&FORMAT=kvn"
-          curl -L -o eop.txt                    "https://celestrak.org/SpaceData/EOP-Last5Years.txt"
-          
+          curl --fail -L -o last-30-days.txt           "https://celestrak.org/NORAD/elements/gp.php?GROUP=last-30-days&FORMAT=tle"
+          curl --fail -L -o space-stations.txt         "https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=tle"
+          curl --fail -L -o 100-brightest.txt          "https://celestrak.org/NORAD/elements/gp.php?GROUP=visual&FORMAT=tle"
+          curl --fail -L -o active.txt                 "https://celestrak.org/NORAD/elements/gp.php?GROUP=active&FORMAT=tle"
+          curl --fail -L -o analyst.txt                "https://celestrak.org/NORAD/elements/gp.php?GROUP=analyst&FORMAT=tle"
+          curl --fail -L -o last-30-days-omm-kvn.txt   "https://celestrak.org/NORAD/elements/gp.php?GROUP=last-30-days&FORMAT=kvn"
+          curl --fail -L -o space-stations-omm-kvn.txt "https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=kvn"
+          curl --fail -L -o 100-brightest-omm-kvn.txt  "https://celestrak.org/NORAD/elements/gp.php?GROUP=visual&FORMAT=kvn"
+          curl --fail -L -o active-omm-kvn.txt         "https://celestrak.org/NORAD/elements/gp.php?GROUP=active&FORMAT=kvn"
+          curl --fail -L -o analyst-omm-kvn.txt        "https://celestrak.org/NORAD/elements/gp.php?GROUP=analyst&FORMAT=kvn"
+          curl --fail -L -o eop.txt                    "https://celestrak.org/SpaceData/EOP-Last5Years.txt"
+
       - name: Commit and push changes
         run: |
           git config --local user.email "action@github.com"


### PR DESCRIPTION
Currently Celestrak has some issue which results in displaying some error page. This leads the CDN to successfully download the error page instead of the TLEs.

With this simple change it will fail instead and not overwrite the existing files with an error message.

Fixes issue #1 